### PR TITLE
Remove dependently typed tracking of binding

### DIFF
--- a/MiniPRL.v
+++ b/MiniPRL.v
@@ -1,28 +1,14 @@
-(* A Coq port of MiniPRL [1]. While we make relatively heavy use of dependent
-   types to keep track of bound variables, there aren't really any proofs. A
-   longer term goal is to implement some of the ideas of Verified NuPRL [2].
+(* A Coq port of MiniPRL [1].
+   A longer term goal is to implement some of the ideas of Verified NuPRL [2].
 
    [1]: https://github.com/jozefg/miniprl
    [2]: http://www.nuprl.org/html/Nuprl2Coq/ *)
-Require Fin Vector String.
-Require Import List Arith.
+Require String.
+Require Import List Arith Bool Omega.
 Import ListNotations.
 
-From StructTact Require Import StructTactics Assoc.
 
-(* The stdlib notations for vector are broken so we roll our own. *sigh* *)
-Arguments Vector.nil {_}.
-Arguments Vector.cons {_} _ {_} _.
-
-Delimit Scope vector_scope with vector.
-Bind Scope vector_scope with Vector.t.
-
-Notation "[ ]" := Vector.nil : vector_scope.
-Notation "h :: t" := (Vector.cons h t) (at level 60, right associativity) : vector_scope.
-Notation " [ x ] " := (x :: [])%vector : vector_scope.
-Notation " [ x ; y ; .. ; z ] " := (x :: (y :: .. (z :: []) ..))%vector : vector_scope.
-
-Open Scope vector_scope.
+From StructTact Require Import StructTactics Assoc BoolUtil.
 
 Set Implicit Arguments.
 
@@ -33,470 +19,333 @@ Module guid.
   Definition eq_dec : forall x y : t, {x = y} + {x <> y} := String.string_dec.
 End guid.
 
-(* Tactic for inverting equalities between dependent pairs where the first
-   component has type nat. *)
-Ltac inv_existT := repeat match goal with
-| [ H : existT _ _ _ = existT _ _ _ |- _ ] =>
-  apply Eqdep_dec.inj_pair2_eq_dec in H; [| solve [auto using PeanoNat.Nat.eq_dec]]
-end; subst.
-
 Module expr.
-  (* De Bruijn indices are *hard*, so to help ourselves out, we'll keep track of
-     the number of free indices in the type. So a closed term will end up having
-     type `expr.t 0`, while a term with one free variable would have type `expr.t
-     1`.
+  Inductive t : Type :=
+  | Var : nat -> t
+  | Lam : t -> t
+  | App : t -> t -> t
+  | Pi : t -> t -> t
 
-     This is fairly easy to understand just by looking at the cases for
-     variables, function application, and abstraction.
+  | Pair : t -> t -> t
+  | Fst : t -> t
+  | Snd : t -> t
+  | Sig : t -> t -> t
 
-     * A variable is represented by an element of `Fin.t n` (which is a type
-       with exactly `n` elements). So for example, in a closed term, since there
-       are no elements of `Fin.t 0` (isomorphic to the empty type), one cannot
-       have a variable at the top level, which makes sense.
+  | tt : t
+  | Unit : t
 
-     * Abstraction takes a body with one more free de Bruijn index and closes it
-       off. So starting from a closed context (`expr.t 0`), going under a lambda
-       gives us one free index to play with (`expr.t 1`). The identity function
-       `\x.x` is thus represented by `Lam (Var Fin.F1)`, where in this case you
-       can think of `Fin.F1` as naming the unique element of the type `Fin.t 1`.
+  | Eq : t -> t -> t -> t
+  | Uni (level : nat) : t
 
-     * Application takes two subterms with the same number of free variables.
-       This makes sense, since it binds no variables.
-
-     Other expression forms are similar to one or another of the above forms.
-     Whenever a subterm binds variables, the type changes to reflect it.
-
-     This is rather a lot of boilerplate-y work, but it really pays off in
-     knowing that the binding structure of terms is being respected. If you've
-     tried to implement a de Bruijn based representation without this help, you
-     will have encountered many bugs due to forgotten lifting etc. Those become
-     static errors with this representation!
-   *)
-  Inductive t : nat -> Type :=
-  | Var : forall n, Fin.t n -> t n
-  | Lam : forall n, t (S n) -> t n
-  | App : forall n, t n -> t n -> t n
-  | Pi : forall n, t n -> t (S n) -> t n
-
-  | Pair : forall n, t n -> t n -> t n
-  | Fst : forall n, t n -> t n
-  | Snd : forall n, t n -> t n
-  | Sig : forall n, t n -> t (S n) -> t n
-
-  | tt : forall {n}, t n
-  | Unit : forall {n}, t n
-
-  | Eq : forall n, t n -> t n -> t n -> t n
-  | Uni : forall (level : nat) {n}, t n
-
-  | Cust : forall {n}, guid.t -> t n
+  | Cust : guid.t -> t
   .
+
+  Module exports.
+    Coercion Var : nat >-> t.
+    Coercion App : expr.t >-> Funclass.
+    Coercion Cust : guid.t >-> t.
+
+    Notation Fst := Fst.
+    Notation Snd := Snd.
+    Notation tt := tt.
+    Notation Unit := Unit.
+    Notation Uni := Uni.
+  End exports.
+
+  Module notations.
+    Bind Scope expr_scope with expr.t.
+    Delimit Scope expr_scope with expr.
+
+
+    Notation "'\' e" := (expr.Lam e) (at level 50) : expr_scope.
+    Notation "A -> B" := (expr.Pi A B) : expr_scope.
+
+    Notation "( x , y , .. , z )" := (expr.Pair .. (expr.Pair x y) .. z) : expr_scope.
+    Notation "A * B" := (expr.Sig A B) : expr_scope.
+    Notation "A = B 'in' C" := (expr.Eq A B C) (at level 50) : expr_scope.
+
+    Local Open Scope expr.
+    Import exports.
+
+    Check (\ 0).
+    Check (\ 0) (\ 0).
+    Check (\ 0) -> (\ 0).
+    Check (0, 0).
+    Check (\ 0) * (\ 0).
+    Check (\ 0) = (\ 0) in Unit.
+  End notations.
 
   (* The rest of this module defines some fundamental operations on the syntax,
      such as lifting and substitution. *)
-
-  (* First up: lifting. `lift` will have the following signature:
-
-         lift (c : nat) {n} (e : t n) : t (S n)
-
-     It takes a term with `n` free variables and shifts them all up by one to
-     make room for a new one. This is complicated by the fact that we don't want
-     to mess up any bound variables in `e` by shifting them around. The
-     parameter `c` keeps track of the number of *bound* variables in the
-     context. If a variable is less than `c`, then it means it is bound by the
-     context and should not be shifted. Users of this function will almost
-     always want to pass 0 for `c`. *)
-
-  (* Before defining lift, we define a helper function to examine a variable
-     (represented by `f : Fin.t n`) and decide whether to shift it (if it is >=
-     c) or leave it alone (< c). We could do this by converting `f` to a nat and
-     then comparing against `c`, but it turns out to be more convenient to just
-     directly examine `c` and `f` by recursion and do the right thing. *)
-  Fixpoint lift_fin (c : nat) {n} (f : Fin.t n) : Fin.t (S n) :=
-    match c with
-    | 0 => Fin.FS f
-    | S c' => match f with
-             | Fin.F1 => Fin.F1
-             | Fin.FS f => Fin.FS (lift_fin c' f)
-             end
-    end.
-
-  (* Now we can define lift. The only hard part is remembering to increment `c`
-     when descending under a binder. *)
-  Fixpoint lift (c : nat) {n} (e : t n) : t (S n) :=
+  Fixpoint lift (c d : nat) (e : t) : t :=
     match e with
-    | Var f => Var (lift_fin c f)
-    | Lam e => Lam (lift (S c) e)
-    | App e1 e2 => App (lift c e1) (lift c e2)
-    | Pi e1 e2 => Pi (lift c e1) (lift (S c) e2)
-    | Pair e1 e2 => Pair (lift c e1) (lift c e2)
-    | Fst e => Fst (lift c e)
-    | Snd e => Snd (lift c e)
-    | Sig e1 e2 => Sig (lift c e1) (lift (S c) e2)
+    | Var n => if n <? c then Var n else Var (n + d)
+    | Lam e => Lam (lift (S c) d e)
+    | App e1 e2 => App (lift c d e1) (lift c d e2)
+    | Pi e1 e2 => Pi (lift c d e1) (lift (S c) d e2)
+    | Pair e1 e2 => Pair (lift c d e1) (lift c d e2)
+    | Fst e => Fst (lift c d e)
+    | Snd e => Snd (lift c d e)
+    | Sig e1 e2 => Sig (lift c d e1) (lift (S c) d e2)
     | tt => tt
     | Unit => Unit
-    | Eq e1 e2 e3 => Eq (lift c e1) (lift c e2) (lift c e3)
+    | Eq e1 e2 e3 => Eq (lift c d e1) (lift c d e2) (lift c d e3)
     | Uni i => Uni i
     | Cust g => Cust g
     end.
 
-  (* Next we define substitution. We go ahead and define multisubstitution
-     because it actually turns out to be slightly simpler. (Instead of needing
-     to check whether a variable is "equal" to a given nat, we just need to look
-     up the variable's index in a vector.)
-
-     Multisubstitution takes an expression `e` with `n` free variables and a map
-     from the free variables of `e` to expressions with `n'` free variables and
-     returns an expression with `n'` free variables. *)
-  Fixpoint subst {n} (e : t n) {n'} : Vector.t (t n') n -> t n' :=
-    let rec_bind {n} (e : t (S n)) {n'} (v : Vector.t (t n') n) :=
-        subst e (Var Fin.F1 :: Vector.map (lift 0) v) in
+  Fixpoint subst (e : t) (from : nat) (to : t) : t :=
+    let rec_bind e := subst e (S from) (lift 0 1 to) in
     match e with
-    | Var f => fun v => Vector.nth v f
-    | Lam e => fun v => Lam (rec_bind e v)
-    | App e1 e2 => fun v => App (subst e1 v) (subst e2 v)
-    | Pi e1 e2 => fun v => Pi (subst e1 v) (rec_bind e2 v)
-    | Pair e1 e2 => fun v => Pair (subst e1 v) (subst e2 v)
-    | Fst e => fun v => Fst (subst e v)
-    | Snd e => fun v => Snd (subst e v)
-    | Sig e1 e2 => fun v => Sig (subst e1 v) (rec_bind e2 v)
-    | tt => fun _ => tt
-    | Unit => fun _ => Unit
-    | Eq e1 e2 e3 => fun v => Eq (subst e1 v) (subst e2 v) (subst e3 v)
-    | Uni i => fun _ => Uni i
-    | Cust g => fun _ => Cust g
+    | Var n => match lt_eq_lt_dec n from with
+              | inleft (left _) => Var n
+              | inleft (right _) => to
+              | inright _ => Var (pred n)
+              end
+    | Lam e => Lam (rec_bind e)
+    | App e1 e2 => App (subst e1 from to) (subst e2 from to)
+    | Pi e1 e2 => Pi (subst e1 from to) (rec_bind e2)
+    | Pair e1 e2 => Pair (subst e1 from to) (subst e2 from to)
+    | Fst e => Fst (subst e from to)
+    | Snd e => Snd (subst e from to)
+    | Sig e1 e2 => Sig (subst e1 from to) (rec_bind e2)
+    | tt => tt
+    | Unit => Unit
+    | Eq e1 e2 e3 => Eq (subst e1 from to) (subst e2 from to) (subst e3 from to)
+    | Uni i => Uni i
+    | Cust g => Cust g
     end.
 
-  (* To recover "normal" substitution of a single free variable, we need a way
-     of saying "don't touch the rest of the variables". This is the purpose of
-     `identity_subst`. It returns a map representing the identity function. *)
-  Fixpoint identity_subst (n : nat) : Vector.t (t n) n :=
-    match n with
-    | 0 => []
-    | S n => Var Fin.F1 :: Vector.map (lift 0) (identity_subst n)
-    end.
-
-  (* Recursion scheme for closed terms.
-     Note that the vanilla scheme for terms requires the motive to generalize
-     over the number of free variables, which is often inconvenient.
-     This scheme let's the motive stay specific to closed terms, if one
-     is willing to give up the ability to recurse under binders.
-
-     Unfortunately this is rather verbose and boring. For each constructor,
-     we need a hypothesis that transforms evidence of P on closed subterms to
-     evidence for P on the parent term. So for example, function application
-     gets two induction hypotheses, one for each sub term. But abstraction (lambda)
-     gets no induction hypotheses because the subterm is not closed, and so we're
-     not allowed to recurse. *)
-  Section rec0.
-    Variable P : t 0 -> Type.
-    Hypothesis PLam : forall e, P (Lam e).
-    Hypothesis PApp : forall e1 e2, P e1 -> P e2 -> P (App e1 e2).
-    Hypothesis PPi : forall e1 e2, P e1 -> P (Pi e1 e2).
-    Hypothesis PPair : forall e1 e2, P e1 -> P e2 -> P (Pair e1 e2).
-    Hypothesis PFst : forall e, P e -> P (Fst e).
-    Hypothesis PSnd : forall e, P e -> P (Snd e).
-    Hypothesis PSig : forall e1 e2, P e1 -> P (Sig e1 e2).
-    Hypothesis Ptt : P tt.
-    Hypothesis Punit : P Unit.
-    Hypothesis PEq : forall e1 e2 e3, P e1 -> P e2 -> P e3 -> P (Eq e1 e2 e3).
-    Hypothesis PUni : forall i, P (Uni i).
-    Hypothesis PCust : forall g, P (Cust g).
-
-
-    Fixpoint rec0 (e : expr.t 0) : P e.
-      refine match e with
-             | Var f => _
-             | @Lam n e => _
-             | App e1 e2 => _
-             | Pi e1 e2 => _
-             | Pair e1 e2 => _
-             | Fst e => _
-             | Snd e => _
-             | Sig e1 e2 => _
-             | tt => _
-             | Unit => _
-             | Eq e1 e2 e3 => _
-             | Uni i => _
-             | Cust i => _
-             end; destruct n; try exact (fun A x => x).
-      - destruct f using Fin.case0.
-      - apply PLam.
-      - apply PApp; apply rec0.
-      - apply PPi; apply rec0.
-      - apply PPair; apply rec0.
-      - apply PFst; apply rec0.
-      - apply PSnd; apply rec0.
-      - apply PSig; apply rec0.
-      - apply Ptt.
-      - apply Punit.
-      - apply PEq; apply rec0.
-      - apply PUni.
-      - apply PCust.
-    Defined.
-  End rec0.
-
-  (* A case analysis scheme for closed terms. Similar to `rec0` above, but no
-     induction hypotheses (recursive calls) are generated at all.
-
-     Implemented as a thin wrapper over `rec0` that ignores IHs.
-   *)
-  Definition case0 (P : t 0 -> Type)
-             (PLam : forall e, P (Lam e))
-             (PApp : forall e1 e2, P (App e1 e2))
-             (PPi : forall e1 e2, P (Pi e1 e2))
-             (PPair : forall e1 e2, P (Pair e1 e2))
-             (PFst : forall e, P (Fst e))
-             (PSnd : forall e, P (Snd e))
-             (PSig : forall e1 e2, P (Sig e1 e2))
-             (Ptt : P tt)
-             (Punit : P Unit)
-             (PEq : forall e1 e2 e3, P (Eq e1 e2 e3))
-             (PUni : forall i, P (Uni i))
-             (PCust : forall g, P (Cust g))
-    : forall e, P e :=
-    rec0 P
-         PLam
-         (fun e1 e2 _ _ => PApp e1 e2)
-         (fun e1 e2 _ => PPi e1 e2)
-         (fun e1 e2 _ _ => PPair e1 e2)
-         (fun e _ => PFst e)
-         (fun e _ => PSnd e)
-         (fun e1 e2 _ => PSig e1 e2)
-         Ptt
-         Punit
-         (fun e1 e2 e3 _ _ _ => PEq e1 e2 e3)
-         PUni
-         PCust
-  .
-
-
-  (* Equality decider. This should really be auto-generated but `decide equality`
-     doesn't support dependent types :( *)
-  Fixpoint eq_dec {n} (e1 : t n) : forall e2 : t n, {e1 = e2} + {e1 <> e2}.
-    refine match e1 in t n0 return forall e2 : t n0, _ with
-           | Var x          => fun e2 =>
-             match e2 as e2' in t n0 return forall x : Fin.t n0, {Var x = e2'} + {Var x <> e2'} with
-             | Var y => fun x =>
-               match Fin.eq_dec x y with
-               | left _ => left _
-               | right _ => right _
-               end
-             | _ => fun x => right _
-             end x
-           | Lam e1         => fun e2 =>
-             match e2 as e2' return forall e1, {Lam e1 = e2'} + {Lam e1 <> e2'} with
-             | Lam e2 => fun e1 =>
-               match eq_dec _ e1 e2 with
-               | left _ => left _
-               | right _ => right _
-               end
-             | _ => fun x => right _
-             end e1
-           | App e11 e12    => fun e2 =>
-             match e2 as e2' return forall e11 e12, {App e11 e12 = e2'} + {App e11 e12 <> e2'} with
-             | App e21 e22 => fun e11 e12 =>
-               match eq_dec _ e11 e21 with
-               | left _ =>
-                 match eq_dec _ e12 e22 with
-                 | left _ => left _
-                 | right _ => right _
-                 end
-               | right _ => right _
-               end
-             | _ => fun _ _ => right _
-             end e11 e12
-           | Pi e11 e12     => fun e2 =>
-             match e2 as e2' return forall e11 e12, {Pi e11 e12 = e2'} + {Pi e11 e12 <> e2'} with
-             | Pi e21 e22 => fun e11 e12 =>
-               match eq_dec _ e11 e21 with
-               | left _ =>
-                 match eq_dec _ e12 e22 with
-                 | left _ => left _
-                 | right _ => right _
-                 end
-               | right _ => right _
-               end
-             | _ => fun _ _ => right _
-             end e11 e12
-           | Pair e11 e12    => fun e2 =>
-             match e2 as e2' return forall e11 e12, {Pair e11 e12 = e2'} + {Pair e11 e12 <> e2'} with
-             | Pair e21 e22 => fun e11 e12 =>
-               match eq_dec _ e11 e21 with
-               | left _ =>
-                 match eq_dec _ e12 e22 with
-                 | left _ => left _
-                 | right _ => right _
-                 end
-               | right _ => right _
-               end
-             | _ => fun _ _ => right _
-             end e11 e12
-           | Fst e1         => fun e2 =>
-             match e2 as e2' return forall e1, {Fst e1 = e2'} + {Fst e1 <> e2'} with
-             | Fst e2 => fun e1 =>
-               match eq_dec _ e1 e2 with
-               | left _ => left _
-               | right _ => right _
-               end
-             | _ => fun _ => right _
-             end e1
-           | Snd e1         => fun e2 =>
-             match e2 as e2' return forall e1, {Snd e1 = e2'} + {Snd e1 <> e2'} with
-             | Snd e2 => fun e1 =>
-               match eq_dec _ e1 e2 with
-               | left _ => left _
-               | right _ => right _
-               end
-             | _ => fun _ => right _
-             end e1
-           | Sig e11 e12     => fun e2 =>
-             match e2 as e2' return forall e11 e12, {Sig e11 e12 = e2'} + {Sig e11 e12 <> e2'} with
-             | Sig e21 e22 => fun e11 e12 =>
-               match eq_dec _ e11 e21 with
-               | left _ =>
-                 match eq_dec _ e12 e22 with
-                 | left _ => left _
-                 | right _ => right _
-                 end
-               | right _ => right _
-               end
-             | _ => fun _ _ => right _
-             end e11 e12
-           | tt             => fun e2 =>
-             match e2 as e2' return {tt = e2'} + {tt <> e2'} with
-             | tt => left _
-             | _ => right _
-             end
-           | Unit           => fun e2 => _
-             match e2 as e2' return {Unit = e2'} + {Unit <> e2'} with
-             | Unit => left _
-             | _ => right _
-             end
-           | Eq e11 e12 e13 => fun e2 =>
-             match e2 as e2' return forall e11 e12 e13, {Eq e11 e12 e13 = e2'} + {Eq e11 e12 e13 <> e2'} with
-             | Eq e21 e22 e23 => fun e11 e12 e13 =>
-               match eq_dec _ e11 e21 with
-               | left _ =>
-                 match eq_dec _ e12 e22 with
-                 | left _ =>
-                   match eq_dec _ e13 e23 with
-                   | left _ => left _
-                   | right _ => right _
-                   end
-                 | right _ => right _
-                 end
-               | right _ => right _
-               end
-             | _ => fun _ _ _ => right _
-             end e11 e12 e13
-           | Uni i          => fun e2 =>
-             match e2 as e2' return {Uni i = e2'} + {Uni i <> e2'} with
-             | Uni j =>
-               match Nat.eq_dec i j with
-               | left _ => left _
-               | right _ => right _
-               end
-             | _ => right _
-             end
-           | Cust g1        => fun e2 =>
-             match e2 as e2' return {Cust g1 = e2'} + {Cust g1 <> e2'} with
-             | Cust g2 =>
-               match guid.eq_dec g1 g2 with
-               | left _ => left _
-               | right _ => right _
-               end
-             | _ => right _
-             end
-           end; try congruence; try solve [intro H; invc H];
-                try solve [intro H; invc H; inv_existT; congruence].
+  Definition eq_dec (e1 e2 : t) : {e1 = e2} + {e1 <> e2}.
+    decide equality;
+    auto using Nat.eq_dec, guid.eq_dec.
   Defined.
+
+  Module wf.
+    Fixpoint t (n : nat) (e : expr.t) : Prop :=
+      match e with
+      | Var i => i < n
+      | Lam e => t (S n) e
+      | App e1 e2 => t n e1 /\ t n e2
+      | Pi e1 e2 => t n e1 /\ t (S n) e2
+      | Pair e1 e2 => t n e1 /\ t n e2
+      | Fst e => t n e
+      | Snd e => t n e
+      | Sig e1 e2 => t n e1 /\ t (S n) e2
+      | tt => True
+      | Unit => True
+      | Eq e1 e2 e3 => t n e1 /\ t n e2 /\ t n e3
+      | Uni i => True
+      | Cust g => True
+      end.
+
+    Lemma lift :
+      forall e n,
+        t n e ->
+        forall c d,
+          t (n + d) (lift c d e).
+    Proof.
+      induction e; simpl; repeat (do_bool; intuition).
+      - break_if; simpl; do_bool; omega.
+      - apply IHe with (n := S n). auto.
+      - apply IHe2 with (n := S n). auto.
+      - apply IHe2 with (n := S n). auto.
+    Qed.
+
+    Lemma Forall_nth_error :
+      forall A (P : A -> Prop) l n x,
+        Forall P l ->
+        nth_error l n = Some x ->
+        P x.
+    Proof.
+      intros.
+      prep_induction H.
+      induction H; intros.
+      - destruct n; discriminate.
+      - destruct n; cbn [nth_error] in *.
+        + find_inversion. auto.
+        + eauto.
+    Qed.
+
+    Lemma Forall_map :
+      forall A (P : A -> Prop) B (Q : B -> Prop) (f : A -> B) l,
+        (forall a, P a -> Q (f a)) ->
+        List.Forall P l ->
+        List.Forall Q (List.map f l).
+    Proof.
+      induction 2; simpl; auto.
+    Qed.
+
+    Lemma lift_0_1:
+      forall (n' : nat) (a : expr.t), t n' a -> t (S n') (expr.lift 0 1 a).
+    Proof.
+      intros. rewrite <- Nat.add_1_r. apply lift.  auto.
+    Qed.
+
+    Lemma subst :
+      forall e from to,
+        t (S from) e ->
+        t from to ->
+        t from (subst e from to).
+    Proof.
+      induction e; simpl; intuition auto using lift_0_1.
+      repeat break_match; simpl; auto.
+      omega.
+    Qed.
+  End wf.
 End expr.
 
-Module context.
-  (* A telescope binding n variables. Later types may refer to earlier bindings. *)
-  Inductive t : nat -> Type :=
-  | nil : t 0
-  | cons : forall n (e : expr.t n) (C : t n), t (S n)
-  .
+Module telescope.
+  Definition t := list expr.t.
+
+  Definition empty : t := [ ].
 
   (* Looking up an element of the telescope lifts the answer so that it is well
-     formed in the context of *all* bindings of the telescope. *)
-  Fixpoint nth {n} (C : t n) : Fin.t n -> expr.t n.
-    refine match C with
-           | nil => fun f => _
-           | cons e C => fun f => _
-           end.
-    - destruct f using Fin.case0.
-    - apply (expr.lift 0).
-      destruct f using Fin.caseS'.
-      + exact e.
-      + exact (nth _ C f).
-  Defined.
-End context.
+     formed in the telescope of *all* bindings of the telescope. *)
+  Fixpoint nth (C : t) (i : nat) : option expr.t :=
+    match C with
+    | nil => None
+    | cons e C => match i with
+                 | 0 => Some (expr.lift 0 1 e)
+                 | S i => match nth C i with
+                         | None => None
+                         | Some e => Some (expr.lift 0 1 e)
+                         end
+                 end
+    end.
 
-Module goal.
-  (* A sequent with n hypotheses. *)
-  Record t (n : nat) : Type :=
+  Module wf.
+    Fixpoint t (k : nat) (C : telescope.t) : Prop :=
+      match C with
+      | [] => True
+      | e :: C => t k C /\ expr.wf.t (k + length C) e
+      end.
+  End wf.
+
+  Lemma nth_wf :
+    forall C k i e,
+      wf.t k C ->
+      nth C i = Some e ->
+      expr.wf.t (k + length C) e.
+  Proof.
+    induction C; intros; destruct i; simpl in *; try discriminate.
+    - find_inversion. break_and.
+      rewrite <- plus_n_Sm.
+      auto using expr.wf.lift_0_1.
+    - break_and. break_match; try discriminate.
+      find_inversion.
+      rewrite <- plus_n_Sm.
+      eauto using expr.wf.lift_0_1.
+  Qed.
+End telescope.
+
+Module sequent.
+  Record t : Type :=
     Make {
-        context : context.t n;
-        goal : expr.t n
+        context : telescope.t;
+        goal : expr.t
     }.
-End goal.
+
+  Module notations.
+    Notation "H >> C" := (Make H C) (at level 61, right associativity) : sequent_scope.
+    Bind Scope sequent_scope with sequent.t.
+    Delimit Scope sequent_scope with sequent.
+  End notations.
+
+  Module wf.
+    Definition t (S : sequent.t) : Prop :=
+      let 'Make C G := S in telescope.wf.t 0 C /\ expr.wf.t (length C) G.
+  End wf.
+End sequent.
 
 Module derivation.
-  (* Derivations also bind variables, so they are indexed just like expressions are. *)
-  Inductive t : nat -> Type :=
-  | Pi_Eq n (D_A : t n) (D_B : t (S n)) : t n
-  | Pi_Intro n (i : nat) (D_A : t n) (D_B : t (S n)) : t n
-  | Pi_Elim n (H : Fin.t n) (a : expr.t n) (D_A : t n) (D_B : t (S n)) : t n
+  Inductive t : Type :=
+  | Pi_Eq (D_A : t) (D_B : t) : t
+  | Pi_Intro (i : nat) (D_A : t) (D_B : t) : t
+  | Pi_Elim (H : nat) (a : expr.t) (D_A : t) (D_B : t) : t
 
-  | Lam_Eq n (i : nat) (D_A : t n) (D_B : t (S n)) : t n
-  | Ap_Eq n (i : nat) (pi_ty : expr.t n) (D_fun D_arg D_cod : t n) : t n
-  | Fun_Ext n (D_lhs D_rhs : t n) (D : t (S n)) : t n
+  | Lam_Eq (i : nat) (D_A : t) (D_B : t) : t
+  | Ap_Eq (i : nat) (pi_ty : expr.t) (D_fun D_arg D_cod : t) : t
+  | Fun_Ext (D_lhs D_rhs : t) (D : t) : t
 
-  | Sig_Eq n (D_A : t n) (D_B : t (S n)) : t n
-  | Sig_Intro n (i : nat) (a : expr.t n) (D_A D_B : t n) (D_eq : t (S n)) : t n
-  | Sig_Elim n (H : Fin.t n) (D_C : t (S (S n))) : t n
-  | Pair_Eq n (i : nat) (D_A D_B : t n) (D_ty : t (S n)) : t n
-  | Fst_Eq n (sig_ty : expr.t n) (D : t n) : t n
-  | Snd_Eq n (i : nat) (sig_ty : expr.t n) (D_a D_B : t n) : t n
+  | Sig_Eq (D_A : t) (D_B : t) : t
+  | Sig_Intro (i : nat) (a : expr.t) (D_A D_B : t) (D_eq : t) : t
+  | Sig_Elim (H : nat) (D_C : t) : t
+  | Pair_Eq (i : nat) (D_A D_B : t) (D_ty : t) : t
+  | Fst_Eq (sig_ty : expr.t) (D : t) : t
+  | Snd_Eq (i : nat) (sig_ty : expr.t) (D_a D_B : t) : t
 
-  | Unit_Eq {n} : t n
-  | tt_Eq {n} : t n
-  | Unit_Intro {n} : t n
+  | Unit_Eq : t
+  | tt_Eq : t
+  | Unit_Intro : t
 
-  | Eq_Eq n (D_ty D_lhs D_rhs : t n) : t n
-  | Eq_Mem_Eq n : t n -> t n
-  | Eq_Sym n : t n -> t n
-  | Eq_Subst n (i : nat) (a : expr.t n) (D_ty : t (S n)) (D_eq D_body : t n) : t n
+  | Eq_Eq (D_ty D_lhs D_rhs : t) : t
+  | Eq_Mem_Eq : t -> t
+  | Eq_Sym : t -> t
+  | Eq_Subst (i : nat) (a : expr.t) (D_ty : t) (D_eq D_body : t) : t
 
-  | Uni_Eq {n} : t n
-  | Cumulative n : t n -> t n
+  | Uni_Eq : t
+  | Cumulative : t -> t
 
-  | Witness n (w : expr.t n) : t n -> t n
+  | Witness (w : expr.t) : t -> t
 
-  | Cut n (g : guid.t) : t (S n) -> t n
+  | Cut (g : guid.t) : t -> t
 
-  | Var n (x : Fin.t n) : t n
-  | Var_Eq {n} : t n
+  | Var (x : nat) : t
+  | Var_Eq : t
   .
+
+(*
+  Module wf.
+    Fixpoint t (n : nat) (D : t) : Prop :=
+      match D with
+      | derivation.Pi_Eq D_A D_B => t n D_A /\ t (S n) D_B
+      | derivation.Pi_Intro i D_A D_B => t n D_A /\ t (S n) D_B
+      | derivation.Pi_Elim x a D_A D_B =>
+        expr.subst (f D_B) (expr.App (expr.Var x) a :: expr.identity_subst _)
+      | derivation.Lam_Eq i D_A D_B => expr.tt
+      | derivation.Ap_Eq i pi_ty D_fun D_arg D_cod => expr.tt
+      | derivation.Fun_Ext D_lhs D_rhs H => expr.tt
+      | derivation.Sig_Eq _ _ => expr.tt
+      | derivation.Sig_Intro i a D_A D_B D_eq => (expr.Pair a (f D_B))
+      | derivation.Sig_Elim H D_C =>
+        expr.subst (f D_C) (expr.Snd (expr.Var H) :: expr.Fst (expr.Var H) :: expr.identity_subst _)
+      | derivation.Pair_Eq _ _ _ _ => expr.tt
+      | derivation.Fst_Eq _ _ => expr.tt
+      | derivation.Snd_Eq _ _ _ _ => expr.tt
+      | derivation.Unit_Eq => expr.tt
+      | derivation.tt_Eq => expr.tt
+      | derivation.Unit_Intro => expr.tt
+      | derivation.Eq_Eq D_ty D_lhs D_rhs => expr.tt
+      | derivation.Eq_Mem_Eq D => expr.tt
+      | derivation.Eq_Sym D => expr.tt
+      | derivation.Eq_Subst i a D_ty D_eq D_body => f D_body
+      | derivation.Uni_Eq => expr.tt
+      | derivation.Cumulative D => expr.tt
+      | derivation.Witness w D => w
+      | derivation.Cut g D =>
+        expr.subst (f D) (expr.Cust g :: expr.identity_subst _)
+      | derivation.Var x => expr.Var x
+      | derivation.Var_Eq => expr.tt
+      end.
+    End wf.
+*)
 End derivation.
 
 Module extract.
-  Fixpoint f {n} (D : derivation.t n) : expr.t n :=
+  Fixpoint f (D : derivation.t) : expr.t :=
     match D with
     | derivation.Pi_Eq D_A D_B => expr.tt
     | derivation.Pi_Intro i D_A D_B => expr.Lam (f D_B)
     | derivation.Pi_Elim x a D_A D_B =>
-      expr.subst (f D_B) (expr.App (expr.Var x) a :: expr.identity_subst _)
+      expr.subst (f D_B) 0 (expr.App (expr.Var x) a)
     | derivation.Lam_Eq i D_A D_B => expr.tt
     | derivation.Ap_Eq i pi_ty D_fun D_arg D_cod => expr.tt
     | derivation.Fun_Ext D_lhs D_rhs H => expr.tt
     | derivation.Sig_Eq _ _ => expr.tt
     | derivation.Sig_Intro i a D_A D_B D_eq => (expr.Pair a (f D_B))
     | derivation.Sig_Elim H D_C =>
-      expr.subst (f D_C) (expr.Snd (expr.Var H) :: expr.Fst (expr.Var H) :: expr.identity_subst _)
+      expr.subst (expr.subst (f D_C) 1 (expr.Fst (expr.Var H))) 0 (expr.Snd (expr.Var H))
     | derivation.Pair_Eq _ _ _ _ => expr.tt
     | derivation.Fst_Eq _ _ => expr.tt
     | derivation.Snd_Eq _ _ _ _ => expr.tt
@@ -511,12 +360,13 @@ Module extract.
     | derivation.Cumulative D => expr.tt
     | derivation.Witness w D => w
     | derivation.Cut g D =>
-      expr.subst (f D) (expr.Cust g :: expr.identity_subst _)
+      expr.subst (f D) 0 (expr.Cust g)
     | derivation.Var x => expr.Var x
     | derivation.Var_Eq => expr.tt
     end.
 End extract.
 
+(*
 Module member.
   (* A proof-relevant proof that `a` is an element of the list `l`. This will be
      used as a dependently typed index into an `hlist.t` below. Analogizing to
@@ -548,7 +398,6 @@ Module member.
            end; auto.
   Defined.
 End member.
-
 
 Module hlist.
   (* Heterogeneous lists. *)
@@ -698,7 +547,7 @@ Module hlist.
   End notations.
 End hlist.
 Import hlist.notations.
-
+*)
 
 Module tactic_monad.
   (* This is just a straight port of MiniPRL's tactic monad. Made possible by
@@ -722,6 +571,7 @@ Module tactic_monad.
     | x :: xs => bind x (fun a => map (List.cons a) (sequence xs))
     end%list.
 
+  (*
   (* Here are two analogous operations: sequencing vectors and hlists. *)
   Fixpoint sequence_vector {R A} {n} (v : Vector.t (t R A) n) : t R (Vector.t A n) :=
     match v with
@@ -735,6 +585,7 @@ Module tactic_monad.
     | hlist.nil => ret hlist.nil
     | hlist.cons x xs => bind x (fun a => map (hlist.cons a) (sequence_hlist xs))
     end.
+  *)
 
   Definition fail {R A} : t R A := fun _ => None.
 
@@ -750,125 +601,121 @@ Module tactic_monad.
   Definition run {A} (x : t A A) : option A := x (@Some _).
 
   Module notations.
-  Notation "m >>= f" := (bind m f) (at level 51, right associativity) : tactic_monad.
-  Notation "m1 >> m2" := (bind m1 (fun _ => m2)) (at level 51, right associativity) : tactic_monad.
+  Notation "m >>= f" := (bind m f) (at level 61, right associativity) : tactic_monad.
+  Notation "m1 >> m2" := (bind m1 (fun _ => m2)) (at level 61, right associativity) : tactic_monad.
 
-  Notation "x <- m ;; f" := (bind m (fun x => f)) (at level 51, right associativity) : tactic_monad.
+  Notation "x <- m ;; f" := (bind m (fun x => f)) (at level 61, right associativity) : tactic_monad.
   End notations.
 
 End tactic_monad.
 Import tactic_monad.notations.
 
 Module tactic_result.
-  (* Because we are tracking binding in the type system, we are going to need to
-     know that a tactic returns a well-scoped term. So `result.t` is
-     parametrized by the number of hypotheses in the context.
-
-     Then, we need to do something kind of complicated to allow the tactic to
-     generate an arbitrary number of subgoals, each with an arbitrary context.
-     This is achieved by adding `binding_structure` below, which describes the
-     number of hypotheses in the context of each subgoal. The length of this
-     list is the number of subgoals. The subgoals are given as an hlist over
-     `binding_structure`. Similarly, the derivation transformer expects an hlist
-     of subderivations and returns a well-scoped derivation in the parent
-     context.
-
-     I think it's fair to say that this is really complicated and probably worth
-     skipping on a first reading. However, it means that we rule out entire
-     classes of bugs since tactics are never exposed to ill-scoped goals or
-     derivations or to a list of goals or derivations with the wrong length.
-     This implies, for example, that the `MalformedEvidence` exception is never
-     thrown in MiniPRL, assuming I have not accidently fixed bugs while
-     porting. *)
-  Record t (D G : nat -> Type) n : Type :=
+  Record t (D G : Type) : Type :=
     Make {
-        binding_structure : list nat;
-        evidence : hlist.t D binding_structure -> D n;
-        goals : hlist.t G binding_structure
+        evidence : list D -> option D;
+        goals : list G;
       }.
-  Arguments Make {_ _} _ _ _ _.
+  Arguments Make {_ _} _ _.
 End tactic_result.
 
 Module Type TACTIC.
-  Parameter derivation goal : nat -> Type.
+  Parameter derivation goal : Type.
 
-  Definition result n := tactic_result.t derivation goal n.
+  Definition result := tactic_result.t derivation goal.
 
-  (* Okay, now this is kind of interesting. We've been carefully tracking
-     binding in the type system, but we don't want users of the tactics to have
-     to annotate them with the number of hypotheses in the contexts. So instead,
-     we require tactics to be polymorphic in the number of hypotheses. If a
-     tactics doesn't like what it sees, it's free to fail in the monad.
-
-     I first tried indexing tactics by the number of hypotheses, but this makes
-     it really hard to express the `split` and `next` combinators
-     below. Experience shows that tactics really are parametric in the number of
-     hypotheses, subject to a few constraints on any configuration data passed
-     as arguments to the tactics, which of course must be well formed in
-     whatever context they happen to run in. *)
-  Definition t := forall R n, goal n -> tactic_monad.t R (result n).
+  Definition t := forall R, goal -> tactic_monad.t R result.
 End TACTIC.
 
 Module tactic <: TACTIC.
   Definition derivation := derivation.t.
-  Definition goal := goal.t.
+  Definition goal := sequent.t.
 
   Definition result := tactic_result.t derivation goal.
 
-  Definition t := forall R n, goal n -> tactic_monad.t R (result n).
+  Definition t := forall R, goal -> tactic_monad.t R result.
 End tactic.
 
 Module refiner.
   Module result.
-    (* The only interesting thing here is the binding structure. A proved result
-       gives a closed derivation and extract. An incomplete result includes a
-       binding structure (argument `l` to constructor `Incomplete` below), and
-       an hlist of subgoals over that binding structure. *)
     Inductive t :=
-    | Proved : derivation.t 0 -> (* extract: *) expr.t 0 -> t
-    | Incomplete l : hlist.t goal.t l -> t
+    | Proved : derivation.t -> (* extract: *) expr.t -> t
+    | Incomplete : list sequent.t -> t
     | Failed : t
     .
   End result.
 
-  Definition prove (thm : expr.t 0) (t : tactic.t) : result.t :=
-    match tactic_monad.run (t _ _ (goal.Make context.nil thm)) with
-    | Some (@tactic_result.Make _ _ _ l ev gs) =>
-      match l as l0 return (hlist.t _ l0 -> _) -> hlist.t _ l0 -> _ with
-      | [] => fun ev gs => let d := ev hlist.nil in result.Proved d (extract.f d)
-      | _ => fun _ _ => result.Incomplete gs
-      end%list ev gs
+  Definition prove (thm : expr.t) (t : tactic.t) : result.t :=
+    match tactic_monad.run (t _ (sequent.Make telescope.empty thm)) with
+    | Some (tactic_result.Make ev gs) =>
+      match gs with
+      | [] => match ev [] with
+             | None => result.Failed
+             | Some d => result.Proved d (extract.f d)
+             end
+      | _ => result.Incomplete gs
+      end
     | None => result.Failed
     end.
 End refiner.
 
+Definition option_bind {A B} (m : option A) (f : A -> option B) : option B :=
+  match m with
+  | None => None
+  | Some a => f a
+  end.
+
 Module primitive_tactics (T : TACTIC).
   Definition id : T.t :=
-    fun R n g => tactic_monad.ret (tactic_result.Make n [n]
-                                  (fun h => hlist.get h member.Here)
-                                  [g]).
+    fun R g => tactic_monad.ret (tactic_result.Make
+                                (fun l => List.hd_error l)
+                                [g]).
 
   Definition choose (t1 t2 : T.t) : T.t :=
-    fun R n g => tactic_monad.choose [fun u => t1 R n g; fun u => t2 R n g].
+    fun R g => tactic_monad.choose [fun u => t1 R g; fun u => t2 R g].
 
-  Definition result_of_hlist l n (ev : hlist.t T.derivation l -> T.derivation n)
-             (rs : hlist.t T.result l) : T.result n.
-    refine (let new_binding_structure :=
-                hlist.to_list (fun n r => tactic_result.binding_structure r) rs
-            in _).
+  Fixpoint chunk (ns : list nat) (ds : list T.derivation) : list (list T.derivation) :=
+    match ns with
+    | [] => []
+    | n :: ns => List.firstn n ds :: chunk ns (List.skipn n ds)
+    end.
 
-    refine (tactic_result.Make _ (List.concat new_binding_structure) _ _).
-    - intros h. apply ev.
-      refine (let chunks := hlist.unconcat _ h in _). clearbody chunks. clear h.
-      refine (let ds := hlist.map_indices_dep
-                          (fun p => hlist.t T.derivation (snd p) -> T.derivation (fst p))
-                          (fun n r => (n, tactic_result.binding_structure r))
-                          (fun n r => tactic_result.evidence r) rs
-              in _).
-      refine (hlist.map2_dep _ _ _ (fun n r c d => _) _ chunks ds).
-      exact (d c).
-    - refine (hlist.concat (hlist.map_indices_dep _ _ (fun n r => tactic_result.goals r) _)).
-  Defined.
+  Fixpoint zipAppOpt {A B} (fs : list (A -> B)) (xs : list A) : option (list B) :=
+    match fs with
+    | [] => match xs with
+           | [] => Some []
+           | _ => None
+           end
+    | f :: fs =>
+      match xs with
+      | [] => None
+      | x :: xs => match zipAppOpt fs xs with
+                  | None => None
+                  | Some ys => Some (f x :: ys)
+                  end
+      end
+    end.
+
+  Fixpoint sequence_option {A} (l : list (option A)) : option (list A) :=
+    match l with
+    | [] => Some []
+    | x :: xs => match x with
+                | None => None
+                | Some a => match sequence_option xs with
+                           | None => None
+                           | Some l => Some (a :: l)
+                           end
+                end
+    end.
+
+  Definition join_evidence (subresults : list T.result) (ds : list T.derivation)
+    : option (list T.derivation) :=
+    let derivChunks :=
+          chunk (List.map (fun x => List.length (x.(tactic_result.goals))) subresults) ds in
+    match zipAppOpt (List.map (fun x => x.(tactic_result.evidence)) subresults) derivChunks with
+    | None => None
+    | Some x => sequence_option x
+    end.
 
   Definition assume_sb {A B R} (x : {A} + {B}) : tactic_monad.t R A :=
     match x with
@@ -884,24 +731,31 @@ Module primitive_tactics (T : TACTIC).
 
   Local Open Scope tactic_monad.
 
+  Definition unwrap {A R} (x : option A) : tactic_monad.t R A :=
+    match x with
+    | Some a => tactic_monad.ret a
+    | None => tactic_monad.fail
+    end.
+
   Definition split (t : T.t) (ts : list T.t) : T.t :=
-    fun R n g =>
-      r <- t R n g ;;
-      let 'tactic_result.Make _ binding_structure evidence goals := r in
-      pf <- assume_sb (Nat.eq_dec (length ts) (length binding_structure)) ;;
-      rs <- tactic_monad.sequence_hlist
-             (hlist.map2 _ (fun n (t : _ -> _) g => t g)
-               (hlist.of_vector _ (fun s a => s R a) _
-                  (Vector.cast (Vector.of_list ts) pf))
-               goals) ;;
-      tactic_monad.ret (result_of_hlist evidence rs).
+    fun R g =>
+      r <- t R g ;;
+      let 'tactic_result.Make evidence goals := r in
+      pf <- assume_sb (Nat.eq_dec (length ts) (length goals)) ;;
+      rs <- unwrap (zipAppOpt (List.map (fun t => t R) ts) goals) ;;
+      subs <- tactic_monad.sequence rs ;;
+      tactic_monad.ret (tactic_result.Make
+                          (fun ds => option_bind (join_evidence subs ds) evidence)
+                          (List.flat_map (fun x => x.(tactic_result.goals)) subs)).
 
   Definition next (t1 t2 : T.t) : T.t :=
-    fun R n g =>
-      r <- t1 R n g ;;
-      let 'tactic_result.Make _ binding_structure evidence goals := r in
-      rs <- tactic_monad.sequence_hlist (hlist.map _ (fun n g => t2 R n g) goals) ;;
-      tactic_monad.ret (result_of_hlist evidence rs).
+    fun R g =>
+      r <- t1 R g ;;
+      let 'tactic_result.Make evidence goals := r in
+      rs <- tactic_monad.sequence (List.map (t2 R) goals) ;;
+      tactic_monad.ret (tactic_result.Make
+                          (fun ds => option_bind (join_evidence rs ds) evidence)
+                          (List.flat_map (fun x => x.(tactic_result.goals)) rs)).
 
   Definition try (t : T.t) : T.t :=
     choose t id.
@@ -916,470 +770,326 @@ End primitive_tactics.
 Module P := primitive_tactics tactic.
 
 Module rules.
-  (* We're finally ready for the rules. As discussed above, our typing
-     discipline guarantees several invariants of the refiner, including
-     well-scopedness. Indeed, a few de Bruijn bugs in MiniPRL's rules were found
-     while porting :) (To be fair, de Bruijn bugs cause code to fail so hard
-     that they likely could have been found by more traditional methods.)*)
   Import P.
+  Import tactic_monad.
   Local Open Scope tactic_monad.
 
-  Definition nullary_derivation {R n} (d : derivation.t n) : tactic_monad.t R _ :=
-    tactic_monad.ret (tactic_result.Make(G:=goal.t) _ [] (fun _ => d) []).
+  Import sequent.notations.
+  Local Open Scope sequent.
+
+  Definition nullary_derivation (d : derivation.t) :=
+    tactic_result.Make(G:=sequent.t) (fun _ => Some d) [].
+
+  Definition unary_derivation (d : derivation.t -> derivation.t) g :=
+    tactic_result.Make(G:=sequent.t) (fun l => match l with
+                                            | [x]  => Some (d x)
+                                            | _ => None
+                                            end) [g].
+
+  Definition binary_derivation (d : derivation.t -> derivation.t -> derivation.t) g1 g2 :=
+    tactic_result.Make(G:=sequent.t)
+      (fun l => match l with
+             | [d1; d2] => Some (d d1 d2)
+             | _ => None
+             end)
+      [g1; g2].
+
+  Definition ternary_derivation (d : derivation.t -> derivation.t ->
+                                     derivation.t -> derivation.t) g1 g2 g3 :=
+    tactic_result.Make(G:=sequent.t)
+      (fun l => match l with
+             | [d1; d2; d3] => Some (d d1 d2 d3)
+             | _ => None
+             end)
+      [g1; g2; g3].
+
 
   Module unit.
+    (* H >> unit = unit in U(i) *)
     Definition Eq : tactic.t :=
-      fun R n g =>
+      fun R g =>
       match g with
-      | goal.Make ctx (expr.Eq expr.Unit expr.Unit (expr.Uni _)) =>
-        nullary_derivation derivation.Unit_Eq
-      | _ => tactic_monad.fail
+      | H >> (expr.Eq expr.Unit expr.Unit (expr.Uni _)) =>
+        ret (nullary_derivation derivation.Unit_Eq)
+      | _ => fail
       end.
 
+    (* H >> unit *)
     Definition Intro : tactic.t :=
-      fun R n g =>
+      fun R g =>
       match g with
-      | goal.Make ctx expr.Unit => nullary_derivation derivation.Unit_Intro
-      | _ => tactic_monad.fail
+      | H >> expr.Unit => ret (nullary_derivation derivation.Unit_Intro)
+      | _ => fail
       end.
 
+    (* H >> tt = tt in unit *)
     Definition TTEq : tactic.t :=
-      fun R n g =>
+      fun R g =>
       match g with
-      | goal.Make ctx (expr.Eq expr.tt expr.tt expr.Unit) =>
-        nullary_derivation derivation.tt_Eq
-      | _ => tactic_monad.fail
+      | H >> (expr.Eq expr.tt expr.tt expr.Unit) =>
+        ret (nullary_derivation derivation.tt_Eq)
+      | _ => fail
       end.
   End unit.
 
   Module pi.
-    Definition Eq : tactic.t.
-      intros R n g.
-      destruct g.
-      revert context.
-      refine match goal with
-             | expr.Eq l r (expr.Uni i) => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear goal n n1 t.
-      revert r.
-      refine match l with
-             | expr.Pi A B => fun r => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert A B.
-      refine match r with
-             | expr.Pi A' B' => fun A B ctx => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear r n.
-      rename n0 into n.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; S n]
-            (fun h => derivation.Pi_Eq (hlist.get h member.Here)
-                                    (hlist.get h (member.There member.Here)))
-            [goal.Make ctx (expr.Eq A A' (expr.Uni i));
-             goal.Make (context.cons A ctx) (expr.Eq B B' (expr.Uni i))])).
-    Defined.
 
-    Definition Intro (i : nat) : tactic.t.
-      intros R n g.
-      destruct g.
-      revert context.
-      refine match goal with
-             | expr.Pi A B => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear n goal.
-      rename n0 into n.
-      intros ctx.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; S n]
-            (fun h => derivation.Pi_Intro i (hlist.get h member.Here)
-                                         (hlist.get h (member.There member.Here)))
-            [goal.Make ctx (expr.Eq A A (expr.Uni i));
-             goal.Make (context.cons A ctx) B])).
-    Defined.
+    (* H >> x:A -> B = x:A' -> B' in U(i)
+         H >> A = A' in U(i)
+         H, x:A >> B = B' in U(i) *)
+    Definition Eq : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq (expr.Pi A B) (expr.Pi A' B') (expr.Uni i) =>
+        ret (binary_derivation derivation.Pi_Eq
+                (H >> (expr.Eq A A' (expr.Uni i)))
+                (A :: H >> (expr.Eq B B' (expr.Uni i))))
+      | _ => fail
+      end.
 
-    Definition Elim (H : nat) (e : sigT expr.t) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      destruct e as [n' e].
-      refine (pf <- assume_sb (Nat.eq_dec n n') ;; _).
-      subst n'.
-      refine (x <- assume_so (Fin.of_nat H n) ;; _).
+    (* H >> x:A -> B
+         H >> A = A in U(i)
+         H, x:A >> B *)
+    Definition Intro (i : nat) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Pi A B =>
+        ret (binary_derivation (derivation.Pi_Intro i)
+                (H >> expr.Eq A A (expr.Uni i))
+                (A :: H >> B))
+      | _ => fail
+      end.
 
-      refine (match context.nth ctx x in expr.t n0
-                    return context.t n0 -> expr.t n0 -> expr.t n0 -> Fin.t n0 ->
-                           tactic_monad.t R (tactic.result n0)
-              with
-             | expr.Pi A B => fun ctx g e x => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end ctx g e x).
-      clear ctx0 g0 e0 x0 n.
-      rename n0 into n.
+    (* H >> C
+         H(n) = x:A -> B
+         H >> e = e in A
+         H, [e/x]B >> C
+     *)
+    Definition Elim (n : nat) (e : expr.t) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> C =>
+        ty <- unwrap (telescope.nth H n) ;;
+        match ty with
+        | expr.Pi A B =>
+          ret (binary_derivation (derivation.Pi_Elim n e)
+                  (H >> expr.Eq e e A)
+                  (expr.subst B 0 e :: H >> expr.lift 0 1 C))
+        | _ => fail
+        end
+      end.
 
-      refine (tactic_monad.ret (tactic_result.Make _ [n; S n]
-            (fun h => derivation.Pi_Elim x e (hlist.get h member.Here)
-                                          (hlist.get h (member.There member.Here)))
-            [goal.Make ctx (expr.Eq e e A);
-             goal.Make (context.cons (expr.subst B (e :: expr.identity_subst n)) ctx)
-                       (expr.lift 0 g)])).
-    Defined.
+    (* H >> \x.e = \x.e' in x:A -> B
+         H >> A = A in U(i)
+         H, x:A >> e = e' in B *)
+    Definition LamEq (i : nat) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq (expr.Lam e) (expr.Lam e') (expr.Pi A B) =>
+        ret (binary_derivation (derivation.Lam_Eq i)
+                (H >> expr.Eq A A (expr.Uni i))
+                (A :: H >> expr.Eq e e' B))
+      | _ => fail
+      end.
 
-    Definition LamEq (i : nat) : tactic.t.
-      intros R n g.
-      destruct g.
-      revert context.
-      refine match goal with
-             | expr.Eq l r t => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear goal n.
-      revert r t.
-      refine match l with
-             | expr.Lam b1 => fun r => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert b1.
-      refine match r with
-             | expr.Lam b2 => fun b1 t => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end.  clear r n.
-      revert b1 b2.
-      refine match t with
-             | expr.Pi A B => fun b1 b2 ctx => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear t n0.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; S n]
-            (fun h => derivation.Lam_Eq i (hlist.get h member.Here)
-                                       (hlist.get h (member.There member.Here)))
-            [goal.Make ctx (expr.Eq A A (expr.Uni i));
-             goal.Make (context.cons A ctx)
-                       (expr.Eq b1 b2 B)])).
-    Defined.
+    (* H >> n1 m1 = n2 m2 in T
+         H >> n1 = n2 in x:A -> B
+         H >> m1 = m2 in A
+         H >> [n1/x]B = T in U(i) *)
+    Definition ApEq (i : nat) (ty : expr.t) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq (expr.App n1 m1) (expr.App n2 m2) T =>
+        match ty with
+        | expr.Pi A B =>
+          ret (ternary_derivation (derivation.Ap_Eq i (expr.Pi A B))
+                  (H >> expr.Eq n1 n2 (expr.Pi A B))
+                  (H >> expr.Eq m1 m2 A)
+                  (H >> expr.Eq (expr.subst B 0 n1) T (expr.Uni i)))
+        | _ => fail
+        end
+      | _ => fail
+      end.
 
+    (* H >> e1 = e2 in x:A -> B
+           H >> e1 = e1 in x:A -> B
+           H >> e2 = e2 in x:A -> B
+           H, x:A >> e1 x = e2 x in B *)
+    Definition FunExt : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq e1 e2 (expr.Pi A B) =>
+        ret (ternary_derivation derivation.Fun_Ext
+                (H >> expr.Eq e1 e1 (expr.Pi A B))
+                (H >> expr.Eq e2 e2 (expr.Pi A B))
+                (A :: H >> expr.Eq (expr.App (expr.lift 0 1 e1) (expr.Var 0))
+                                   (expr.App (expr.lift 0 1 e2) (expr.Var 0))
+                                   B))
 
-    Definition ApEq (i : nat) (ty : sigT expr.t) : tactic.t.
-      intros R n g.
-      destruct g.
-      destruct ty as [n' ty].
-      refine (pf <- assume_sb (Nat.eq_dec n n') ;; _).
-      subst n'.
-      revert goal context.
-      refine match ty with
-             | expr.Pi A B => fun goal => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear ty n.
-      revert A B.
-      refine match goal with
-             | expr.Eq l r t => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear goal. clear n0.
-      revert r t.
-      refine match l with
-             | expr.App n1 m1 => fun r => _
-             | _ => fun _ _ _ _ _ => tactic_monad.fail
-             end. clear l n.
-      revert n1 m1.
-      refine match r with
-             | expr.App n2 m2 => fun n1 m1 t A B ctx => _
-             | _ => fun _ _ _ _ _ _ => tactic_monad.fail
-             end. clear r n0.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; n; n]
-            (fun h => derivation.Ap_Eq i (expr.Pi A B)
-                                    (hlist.get h member.Here)
-                                    (hlist.get h (member.There member.Here))
-                                    (hlist.get h (member.There (member.There member.Here))))
-            [goal.Make ctx (expr.Eq n1 n2 (expr.Pi A B));
-             goal.Make ctx (expr.Eq m1 m2 A);
-             goal.Make ctx (expr.Eq (expr.subst B (n1 :: expr.identity_subst n))
-                                    t
-                                    (expr.Uni i))])).
-    Defined.
-
-    Definition FunExt : tactic.t.
-      intros R n g.
-      destruct g.
-      revert context.
-      refine match goal with
-             | expr.Eq l r t => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear goal n.
-      revert l r.
-      refine match t with
-             | expr.Pi A B => fun l r ctx => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; n; S n]
-            (fun h => derivation.Fun_Ext (hlist.get h member.Here)
-                                      (hlist.get h (member.There member.Here))
-                                      (hlist.get h (member.There (member.There member.Here))))
-            [goal.Make ctx (expr.Eq l l (expr.Pi A B));
-             goal.Make ctx (expr.Eq r r (expr.Pi A B));
-             goal.Make (context.cons A ctx)
-                       (expr.Eq (expr.App (expr.lift 0 l) (expr.Var Fin.F1))
-                                (expr.App (expr.lift 0 r) (expr.Var Fin.F1))
-                                B)])).
-    Defined.
+      | _ => fail
+      end.
   End pi.
 
   Module uni.
-    Definition Eq : tactic.t.
-      intros R n g.
-      destruct g.
-      revert context.
-      refine match goal with
-             | expr.Eq (expr.Uni i) (expr.Uni j) (expr.Uni k) => fun ctx => _
-             | _ => fun _ => tactic_monad.fail
-             end.
-      refine (_ <- assume_sb (Nat.eq_dec i j) ;; _).
-      refine (_ <- assume_sb (Nat.eq_dec (S i) k) ;; _).
-      exact (nullary_derivation derivation.Uni_Eq).
-    Defined.
+    (* H >> U(i) = U(i) in U(i+1) *)
+    Definition Eq : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq (expr.Uni i) (expr.Uni j) (expr.Uni k) =>
+        _ <- assume_sb (Nat.eq_dec i j) ;;
+        _ <- assume_sb (Nat.eq_dec (S i) k) ;;
+        ret (nullary_derivation derivation.Uni_Eq)
+      | _ => fail
+      end.
 
-    Definition Cumulative : tactic.t.
-      intros R n g.
-      destruct g.
-      revert context.
-      refine match goal with
-             | expr.Eq A B (expr.Uni (S i)) => fun ctx => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear goal n t n1 n2.
-      rename n0 into n.
-      refine (tactic_monad.ret (tactic_result.Make _ [n]
-            (fun h => derivation.Cumulative (hlist.get h member.Here))
-            [goal.Make ctx (expr.Eq A B (expr.Uni i))])).
-    Defined.
+    (* H >> A = B in U(i+1)
+         H >> A = B in U(i) *)
+    Definition Cumulative : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq A B (expr.Uni (S i)) =>
+        ret (unary_derivation derivation.Cumulative
+                (H >> expr.Eq A B (expr.Uni i)))
+      | _ => fail
+      end.
   End uni.
 
   Module general.
-    Definition Hyp (H : nat) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      refine (x <- assume_so (Fin.of_nat H n) ;; _).
-      refine (_ <- assume_sb (expr.eq_dec g (context.nth ctx x)) ;; _).
-      exact (nullary_derivation (derivation.Var x)).
-    Defined.
+    (* H >> C
+         H(n) = C *)
+    Definition Hyp (n : nat) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> C =>
+        ty <- unwrap (telescope.nth H n) ;;
+        _ <- assume_sb (expr.eq_dec C ty) ;;
+        ret (nullary_derivation (derivation.Var n))
+      end.
 
-    Definition HypEq : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      revert ctx.
-      refine match g with
-             | expr.Eq l r t => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear g n.
-      revert r t.
-      refine match l with
-             | expr.Var x1 => fun r => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert x1.
-      refine match r with
-             | expr.Var x2 => fun x1 t ctx => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end.  clear r n.
-      refine (_ <- assume_sb (Fin.eq_dec x1 x2) ;; _).
-      refine (_ <- assume_sb (expr.eq_dec t (context.nth ctx x1)) ;; _).
-      exact (nullary_derivation derivation.Var_Eq).
-    Defined.
+    (* H >> x = x in A
+         H(x) = A *)
+    Definition HypEq : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq (expr.Var n1) (expr.Var n2) A =>
+        _ <- assume_sb (Nat.eq_dec n1 n2) ;;
+        ty <- unwrap (telescope.nth H n1) ;;
+        _ <- assume_sb (expr.eq_dec A ty) ;;
+        ret (nullary_derivation derivation.Var_Eq)
+      | _ => fail
+      end.
   End general.
 
   Module eq.
-    Definition Eq : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      revert ctx.
-      refine match g with
-             | expr.Eq l r (expr.Uni i) => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear g n n1 t.
-      revert r.
-      refine match l with
-             | expr.Eq m1 n1 A1 => fun r => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert m1 n1 A1.
-      refine match r with
-             | expr.Eq m2 n2 A2 => fun m1 n1 A1 ctx => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear r n.
-      rename n0 into n.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; n; n]
-            (fun h => derivation.Eq_Eq (hlist.get h member.Here)
-                                    (hlist.get h (member.There member.Here))
-                                    (hlist.get h (member.There (member.There member.Here))))
-            [goal.Make ctx (expr.Eq A1 A2 (expr.Uni i));
-             goal.Make ctx (expr.Eq m1 m2 A1);
-             goal.Make ctx (expr.Eq n1 n2 A1)])).
-    Defined.
+    (* H >>   m1 = n1 in A1   =   m2 = n2 in A2   in U(i)
+           H >> A1 = A2 in U(i)
+           H >> m1 = m2 in A1
+           H >> n1 = n2 in A1 *)
+    Definition Eq : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Eq (expr.Eq m1 n1 A1) (expr.Eq m2 n2 A2) (expr.Uni i) =>
+        ret (ternary_derivation derivation.Eq_Eq
+                (H >> expr.Eq A1 A2 (expr.Uni i))
+                (H >> expr.Eq m1 m2 A1)
+                (H >> expr.Eq n1 n2 A1))
+      | _ => fail
+      end.
   End eq.
 
+  Import expr.exports.
+  Import expr.notations.
+  Local Open Scope expr.
+
   Module sig.
-    Definition Eq : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      revert ctx.
-      refine match g with
-             | expr.Eq l r (expr.Uni i) => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear g n n1 t.
-      revert r.
-      refine match l with
-             | expr.Sig A B => fun r => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert A B.
-      refine match r with
-             | expr.Sig A' B' => fun A B ctx => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear r n.
-      rename n0 into n.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; S n]
-            (fun h => derivation.Sig_Eq (hlist.get h member.Here)
-                                     (hlist.get h (member.There member.Here)))
-            [goal.Make ctx (expr.Eq A A' (expr.Uni i));
-             goal.Make (context.cons A ctx) (expr.Eq B B' (expr.Uni i))])).
-    Defined.
+    (* H >> x:A * B = x:A' * B' in U(i)
+           H >> A = A' in U(i)
+           H, x:A >> B = B' in U(i) *)
+    Definition Eq : tactic.t :=
+      fun R g =>
+      match g with
+      | H >>  A * B = A' * B' in expr.Uni i =>
+        ret (binary_derivation derivation.Sig_Eq
+               (H >> A = A' in expr.Uni i)
+               (A :: H >> B = B' in expr.Uni i))
+      | _ => fail
+      end.
 
-    Definition Intro (i : nat) (e : {n : nat & expr.t n}) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      destruct e as [n' e].
-      refine (pf <- assume_sb (Nat.eq_dec n n') ;; _).
-      subst n'.
-      revert e ctx.
-      refine match g with
-             | expr.Sig A B => fun a ctx => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear g n.
-      rename n0 into n.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; n; S n]
-            (fun h => derivation.Sig_Intro i a
-                                        (hlist.get h member.Here)
-                                        (hlist.get h (member.There member.Here))
-                                        (hlist.get h (member.There (member.There member.Here))))
-            [goal.Make ctx (expr.Eq a a A);
-             goal.Make ctx (expr.subst B (a :: expr.identity_subst n));
-             goal.Make (context.cons A ctx) (expr.Eq B B (expr.Uni i))])).
-    Defined.
+    (* H >> x:A * B
+         H >> a = a in A
+         H >> [a/x]B
+         H, x:A >> B = B in U(i) *)
+    Definition Intro (i : nat) (a : expr.t) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> A * B =>
+        ret (ternary_derivation (derivation.Sig_Intro i a)
+                (H >> a = a in A)
+                (H >> expr.subst B 0 a)
+                (A :: H >> B = B in Uni i))
+      | _ => fail
+      end.
 
-    Definition Elim (H : nat) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      refine (x <- assume_so (Fin.of_nat H n) ;; _).
+    (* H >> C
+         H(n) = x:A * B
+         H, x:A, B >> C *)
+    Definition Elim (n : nat) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> C =>
+        ty <- unwrap (telescope.nth H n) ;;
+        match ty with
+        | A * B =>
+          ret (unary_derivation (derivation.Sig_Elim n)
+                (B :: A :: H >> expr.lift 0 2 C))
+        | _ => fail
+        end
+      end.
 
-      refine (match context.nth ctx x in expr.t n0
-                    return context.t n0 -> expr.t n0 -> Fin.t n0 ->
-                           tactic_monad.t R (tactic.result n0)
-              with
-             | expr.Sig A B => fun ctx g x => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end ctx g x).
-      clear ctx0 g0 x0 n.
-      rename n0 into n.
-      refine (tactic_monad.ret (tactic_result.Make _ [S (S n)]
-            (fun h => derivation.Sig_Elim x
-                                       (hlist.get h member.Here))
-            [goal.Make (context.cons B (context.cons A ctx)) (expr.lift 0 (expr.lift 0 g))])).
-    Defined.
+    (* H >> (a,b) = (a',b') in x:A * B
+         H >> a = a' in A
+         H >> b = b' in [a/x]B
+         H, x:A >> B = B in U(i) *)
+    Definition PairEq (i : nat) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> (a,b) = (a',b') in A * B =>
+        ret (ternary_derivation (derivation.Pair_Eq i)
+                (H >> a = a' in A)
+                (H >> b = b' in expr.subst B 0 a)
+                (A :: H >> B = B in Uni i))
+      | _ => fail
+      end.
 
-    Definition PairEq (i : nat) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      revert ctx.
-      refine match g with
-             | expr.Eq l r t => _
-             | _ => fun _ => tactic_monad.fail
-             end. clear g n.
-      revert r t.
-      refine match l with
-             | expr.Pair a b => fun r => _
-             | _ => fun _ _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert a b.
-      refine match r with
-             | expr.Pair a' b' => fun a b t => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear r n.
-      revert a b a' b'.
-      refine match t with
-             | expr.Sig A B => fun a b a' b' ctx => _
-             | _ => fun _ _ _ _ _ => tactic_monad.fail
-             end. clear t n0.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; n; S n]
-            (fun h => derivation.Pair_Eq i
-                                       (hlist.get h member.Here)
-                                       (hlist.get h (member.There member.Here))
-                                       (hlist.get h (member.There (member.There member.Here))))
-            [goal.Make ctx (expr.Eq a a' A);
-             goal.Make ctx (expr.Eq b b' (expr.subst B (a :: expr.identity_subst n)));
-             goal.Make (context.cons A ctx) (expr.Eq B B (expr.Uni i))])).
-    Defined.
+    (* H >> fst m1 = fst m2 in A
+         H >> m1 = m2 in A * B
+     *)
+    Definition FstEq (B : expr.t) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Fst m1 = expr.Fst m2 in A =>
+        ret (unary_derivation (derivation.Fst_Eq B)
+                (H >> m1 = m2 in A * B))
+      | _ => fail
+      end.
 
 
-    Definition FstEq (ty : {n : nat & expr.t n}) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      destruct ty as [n' ty].
-      refine (pf <- assume_sb (Nat.eq_dec n n') ;; _).
-      subst n'.
-      revert ty ctx.
-      refine match g with
-             | expr.Eq l r t => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear g n.
-      revert r t.
-      refine match l with
-             | expr.Fst m1 => fun r => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert m1.
-      refine match r with
-             | expr.Fst m2 => fun m1 t ty ctx => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear r n.
-      revert m1 m2 t ctx.
-      refine match ty with
-             | expr.Sig A B => fun m1 m2 t ctx => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear n0 ty.
-      refine (_ <- assume_sb (expr.eq_dec t A) ;; _).
-      refine (tactic_monad.ret (tactic_result.Make _ [n]
-            (fun h => derivation.Fst_Eq (expr.Sig A B) (hlist.get h member.Here))
-            [goal.Make ctx (expr.Eq m1 m2 (expr.Sig A B))])).
-    Defined.
-
-    Definition SndEq (i : nat) (ty : {n : nat & expr.t n}) : tactic.t.
-      intros R n g.
-      destruct g as [ctx g].
-      destruct ty as [n' ty].
-      refine (pf <- assume_sb (Nat.eq_dec n n') ;; _).
-      subst n'.
-      revert ty ctx.
-      refine match g with
-             | expr.Eq l r B' => _
-             | _ => fun _ _ => tactic_monad.fail
-             end. clear g n.
-      revert r B'.
-      refine match l with
-             | expr.Snd m1 => fun r => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear l n0.
-      revert m1.
-      refine match r with
-             | expr.Snd m2 => fun m1 B' ty ctx => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear r n.
-      revert m1 m2 B' ctx.
-      refine match ty with
-             | expr.Sig A B => fun m1 m2 B' ctx => _
-             | _ => fun _ _ _ _ => tactic_monad.fail
-             end. clear n0 ty.
-      refine (tactic_monad.ret (tactic_result.Make _ [n; n]
-            (fun h => derivation.Snd_Eq i (expr.Sig A B)
-                                     (hlist.get h member.Here)
-                                     (hlist.get h (member.There member.Here)))
-            [goal.Make ctx (expr.Eq m1 m2 (expr.Sig A B));
-             goal.Make ctx (expr.Eq (expr.subst B (expr.Fst m1 :: expr.identity_subst _))
-                                    B'
-                                    (expr.Uni i))])).
-    Defined.
+    (* H >> snd m1 = snd m2 in C
+         H >> m1 = m2 in x:A * B
+         H >> [fst m1/x]B = C in U(i) *)
+    Definition SndEq (i : nat) (ty : expr.t) : tactic.t :=
+      fun R g =>
+      match g with
+      | H >> expr.Snd m1 = expr.Snd m2 in C =>
+        match ty with
+        | A * B =>
+          ret (binary_derivation (derivation.Snd_Eq i ty)
+                 (H >> m1 = m2 in A * B)
+                 (H >> expr.subst B 0 (Fst m1) = C in Uni i))
+        | _ => fail
+        end
+      | _ => fail
+      end.
   End sig.
 End rules.
 Import rules.
@@ -1414,96 +1124,136 @@ Module ast.
   | Cust : guid.t -> t
   .
 
-  (* Helper function to find the first occurence of a particular value in a vector. *)
-  Fixpoint v_index_of {A} (A_eq_dec : forall a1 a2 : A, {a1 = a2} + {a1 <> a2})
+  Module exports.
+    Coercion Var : String.string >-> t.
+    Coercion App : t >-> Funclass.
+    Coercion Cust : guid.t >-> t.
+
+    Notation Fst := Fst.
+    Notation Snd := Snd.
+    Notation tt := tt.
+    Notation Unit := Unit.
+    Notation Uni := Uni.
+  End exports.
+
+  Module notations.
+    Bind Scope ast_scope with ast.t.
+    Delimit Scope ast_scope with ast.
+    Import String.
+
+    Notation "'\' x ',' e" := (ast.Lam x e) (at level 50) : ast_scope.
+    Notation "{ x : A } -> B" := (ast.Pi x A B) (at level 0, x at level 99, B at level 200) : ast_scope.
+    Notation "A -> B" := (ast.Pi "_" A B) (at level 99, B at level 200).
+
+    Notation "( x , y , .. , z )" := (ast.Pair .. (ast.Pair x y) .. z) : ast_scope.
+    Notation "{ x : A } * B" := (ast.Sig x A B) (at level 0, x at level 99, B at level 200) : ast_scope.
+    Notation "A * B" := (ast.Sig "_" A B) : ast_scope.
+    Notation "A = B 'in' C" := (ast.Eq A B C) (at level 50) : ast_scope.
+
+    Local Open Scope ast.
+    Import String.
+    Local Open Scope string.
+    Import exports.
+
+    Check (\ "x", "x").
+    Check (\ "x", "x") (\ "x", "x").
+    Check {"x" : "A"} -> "B".
+    Check ("x", "x").
+    Check {"_" : (\ "x", "x")} * (\ "x", "x").
+    Check (\ "x", "x") = (\ "x", "x") in Unit.
+  End notations.
+
+
+  (* Helper function to find the first occurence of a particular value in a list. *)
+  Fixpoint index_of {A} (A_eq_dec : forall a1 a2 : A, {a1 = a2} + {a1 <> a2})
            (a : A)
-           {n} (v : Vector.t A n) : option (Fin.t n) :=
-    match v with
+           (l : list A) : option nat :=
+    match l with
     | [] => None
-    | a' :: v => if A_eq_dec a a'
-                then Some Fin.F1
-                else match v_index_of A_eq_dec a v with
+    | a' :: l => if A_eq_dec a a'
+                then Some 0
+                else match index_of A_eq_dec a l with
                      | None => None
-                     | Some i => Some (Fin.FS i)
+                     | Some i => Some (S i)
                      end
     end.
 
-  Fixpoint to_expr' {n} (v : Vector.t String.string n) (a : t) : option (expr.t n) :=
+  Fixpoint to_expr' (l : list String.string) (a : t) : option expr.t :=
     match a with
     | Var s =>
-      match v_index_of String.string_dec s v with
+      match index_of String.string_dec s l with
       | Some i => Some (expr.Var i)
       | None => None
       end
     | Lam s a =>
-      match to_expr' (s :: v) a with None => None
+      match to_expr' (s :: l) a with None => None
       | Some a => Some (expr.Lam a)
       end
     | App a1 a2 =>
-      match to_expr' v a1 with None => None
+      match to_expr' l a1 with None => None
       | Some a1 =>
-      match to_expr' v a2 with None => None
+      match to_expr' l a2 with None => None
       | Some a2 => Some (expr.App a1 a2)
       end end
     | Pi s a1 a2 =>
-      match to_expr' v a1 with None => None
+      match to_expr' l a1 with None => None
       | Some a1 =>
-      match to_expr' (s :: v) a2 with None => None
+      match to_expr' (s :: l) a2 with None => None
       | Some a2 => Some (expr.Pi a1 a2)
       end end
     | Pair a1 a2 =>
-      match to_expr' v a1 with None => None
+      match to_expr' l a1 with None => None
       | Some a1 =>
-      match to_expr' v a2 with None => None
+      match to_expr' l a2 with None => None
       | Some a2 => Some (expr.Pair a1 a2)
       end end
     | Fst a =>
-      match to_expr' v a with None => None
+      match to_expr' l a with None => None
       | Some a => Some (expr.Fst a)
       end
     | Snd a =>
-      match to_expr' v a with None => None
+      match to_expr' l a with None => None
       | Some a => Some (expr.Snd a)
       end
     | Sig s a1 a2 =>
-      match to_expr' v a1 with None => None
+      match to_expr' l a1 with None => None
       | Some a1 =>
-      match to_expr' (s :: v) a2 with None => None
+      match to_expr' (s :: l) a2 with None => None
       | Some a2 => Some (expr.Sig a1 a2)
       end end
     | tt => Some expr.tt
     | Unit => Some expr.Unit
     | Eq a1 a2 a3 =>
-      match to_expr' v a1 with None => None
+      match to_expr' l a1 with None => None
       | Some a1 =>
-      match to_expr' v a2 with None => None
+      match to_expr' l a2 with None => None
       | Some a2 =>
-      match to_expr' v a3 with None => None
+      match to_expr' l a3 with None => None
       | Some a3 => Some (expr.Eq a1 a2 a3)
       end end end
     | Uni i => Some (expr.Uni i)
     | Cust g => Some (expr.Cust g)
     end.
 
-  Fixpoint to_expr (a : t) : option (expr.t 0) :=
+  Fixpoint to_expr (a : t) : option expr.t :=
     to_expr' [] a.
 
 End ast.
 
 Open Scope string_scope.
 
-(* Writing Var all the time gets tiresome... *)
-Coercion ast.Var : String.string >-> ast.t.
-
 (* Here's an actually interesting theorem: function extensionality. Much *much*
    nicer to write this as an ast than as an expr! *)
+Import ast.exports.
+Import ast.notations.
+
 Definition ast_funext : ast.t :=
-  ast.Pi "A" (ast.Uni 0)
-    (ast.Pi "B" (ast.Uni 0)
-    (ast.Pi "f" (ast.Pi "_" "A" "B")
-    (ast.Pi "g" (ast.Pi "_" "A" "B")
-    (ast.Pi "_" (ast.Pi "x" "A" (ast.Eq (ast.App "f" "x") (ast.App "g" "x") "B"))
-        (ast.Eq "f" "g" (ast.Pi "_" "A" "B")))))).
+  {"A" : Uni 0} ->
+  {"B" : Uni 0} ->
+  {"f" : "A" -> "B"} ->
+  {"g" : "A" -> "B"} ->
+  ({"x" : "A"} -> "f" "x" = "g" "x" in "B") ->
+  "f" = "g" in ("A" -> "B").
 
 (* We can take a look at the resulting expr. *)
 Eval compute in ast.to_expr (ast_funext).
@@ -1523,15 +1273,15 @@ Ltac parse e :=
 (* When working in the refiner, we'll want to parse open terms in the context of
    the current goal. `parse'` takes the context as an extra argument to
    facilitate this. *)
-Ltac parse' v e :=
-  let e := eval compute in (ast.to_expr' v e)
+Ltac parse' l e :=
+  let e := eval compute in (ast.to_expr' l e)
   in match e with
      | Some ?x => exact x
      end.
 
 (* We can use `parse` to conveniently define the expr for function
    extensionality without copy-pasting. *)
-Definition funext : expr.t 0 := ltac:(parse ast_funext).
+Definition funext : expr.t := ltac:(parse ast_funext).
 
 (* A few simple notations for the tactics. *)
 Notation "t ;; l" := (P.split t l) (at level 50, left associativity).
@@ -1542,12 +1292,12 @@ Module tac_info.
   Record t :=
     Make {
         i : option nat;
-        e : option {n : nat & expr.t n}
+        e : option expr.t
       }.
 
   Definition empty : t := Make None None.
   Definition level (i : nat) : t := Make (Some i) None.
-  Definition arg (e : {n : nat & expr.t n}) : t := Make None (Some e).
+  Definition arg (e : expr.t) : t := Make None (Some e).
 
   Definition get_i (x : t) {R} : tactic_monad.t R nat :=
     match i x with
@@ -1555,7 +1305,7 @@ Module tac_info.
     | None => tactic_monad.fail
     end.
 
-  Definition get_e (x : t) {R} : tactic_monad.t R {n : nat & expr.t n} :=
+  Definition get_e (x : t) {R} : tactic_monad.t R expr.t :=
     match e x with
     | Some e => tactic_monad.ret e
     | None => tactic_monad.fail
@@ -1564,7 +1314,7 @@ End tac_info.
 
 Module tac.
   Definition Intro (info : tac_info.t) : tactic.t.
-    refine (fun R n g => _).
+    refine (fun R g => _).
     refine (tactic_monad.choose
               [fun _ => unit.Intro g;
                fun _ => tactic_monad.bind (tac_info.get_i info) (fun i => pi.Intro i g);
@@ -1573,7 +1323,7 @@ Module tac.
   Defined.
 
   Definition Eq (info : tac_info.t) : tactic.t.
-    refine (fun R n g => _).
+    refine (fun R g => _).
     refine (tactic_monad.choose
               [fun _ => unit.Eq g;
                fun _ => pi.Eq g;
@@ -1587,16 +1337,24 @@ Module tac.
            ]).
   Defined.
 
+  Import sequent.notations.
+  Local Open Scope sequent.
+
   Definition Assumption : tactic.t.
-    refine (fun R n g => _).
+    refine (fun R g => _).
     refine (let fix go k :=
                 match k with
                 | 0 => P.id g
                 | S k => tactic_monad.choose [fun _ => general.Hyp k g; fun _ => go k]
                 end in _).
-    exact (go n).
+    exact (match g with
+           | H >> _ => go (length H)
+           end).
   Defined.
 End tac.
+
+Import sequent.notations.
+Open Scope sequent.
 
 (* Let's prove function extensionality! *)
 Eval cbv in
@@ -1608,44 +1366,43 @@ Eval cbv in
                  pi.Intro 0 ;;; go_eq ;;;
                  pi.Intro 0 ;;; go_eq ;; [
                         pi.ApEq 0
-                           (existT _ _ ltac:(parse' ["x"; "g"; "f"; "B"; "A"]
+                           (ltac:(parse' ["x"; "g"; "f"; "B"; "A"]
                                                     (ast.Pi "_" "A" "B")));;; go_eq;
                         pi.ApEq 0
-                           (existT _ _ ltac:(parse' ["x"; "g"; "f"; "B"; "A"]
+                           (ltac:(parse' ["x"; "g"; "f"; "B"; "A"]
                                                     (ast.Pi "_" "A" "B")));;; go_eq;
-                        pi.FunExt;;; go_eq;;;
+
+                        pi.FunExt;;; go_eq ;;;
                         pi.Elim 1
-                          (existT _ _ ltac:(parse' ["x"; "H"; "g"; "f"; "B"; "A"] "x"));;;
+                          (ltac:(parse' ["x"; "H"; "g"; "f"; "B"; "A"] "x"));;;
                           go_eq;;;
                         tac.Assumption]).
 
 Definition ast_proj1 : ast.t :=
-   ast.Pi "A" (ast.Uni 0)
-  (ast.Pi "B" (ast.Pi "_" "A" (ast.Uni 0))
-  (ast.Pi "_" (ast.Sig "x" "A" (ast.App "B" "x"))
-          "A")).
+  {"A" : Uni 0} ->
+  {"B" : "A" -> Uni 0} ->
+  ({"x" : "A"} * "B" "x") ->
+  "A".
 
-Definition proj1 : expr.t 0 := ltac:(parse ast_proj1).
+Definition proj1 : expr.t := ltac:(parse ast_proj1).
 
 Eval cbv in refiner.prove proj1
   (pi.Intro 1;; [uni.Eq;
    pi.Intro 1;; [pi.Eq;; [uni.Cumulative;;; general.HypEq; uni.Eq];
    pi.Intro 0;; [sig.Eq;; [general.HypEq;
        pi.ApEq 1
-         (existT _ _ ltac:(parse' ["x"; "B"; "A"] (ast.Pi "y" "A" (ast.Uni 0))));;
+         (ltac:(parse' ["x"; "B"; "A"] (ast.Pi "y" "A" (ast.Uni 0))));;
        [general.HypEq; general.HypEq; uni.Eq]];
    sig.Elim 0;; [general.Hyp 1]]]]).
 
 
 Definition ast_snd_eq : ast.t :=
-  ast.Eq (ast.Snd (ast.Pair ast.tt ast.tt))
-         (ast.Snd (ast.Pair ast.tt ast.tt))
-         ast.Unit.
+  Snd (tt, tt) = Snd (tt, tt) in Unit.
 
-Definition snd_eq : expr.t 0 := ltac:(parse ast_snd_eq).
+Definition snd_eq : expr.t := ltac:(parse ast_snd_eq).
 
 Eval cbv in refiner.prove snd_eq
-   (sig.SndEq 0 (existT _ _ ltac:(parse (ast.Sig "_" ast.Unit ast.Unit))) ;;
+   (sig.SndEq 0 (ltac:(parse (ast.Sig "_" ast.Unit ast.Unit))) ;;
      [sig.PairEq 0 ;; [unit.TTEq; unit.TTEq; unit.Eq];
       unit.Eq]).
 
@@ -1737,7 +1494,7 @@ Module step.
 
   Definition f (e : expr.t 0) : result.t :=
     expr.rec0
-      _
+      (fun _ => result.t)
       (* Lam *) (fun _ => result.Value)
       (* App *) (fun e1 e2 IHe1 _ =>
                    match IHe1 with

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # miniprl-coq
 
 This is a Coq port of
-[MiniPRL](https://github.com/jozefg/miniprl). While it makes
-relatively heavy use of dependent types to keep track of bound
-variables, there aren't really any proofs yet. A longer term goal is
+[MiniPRL](https://github.com/jozefg/miniprl). A longer term goal is
 to implement some of the ideas of
 [Verified NuPRL](http://www.nuprl.org/html/Nuprl2Coq/) by showing the
 rules of the proof theory sound with respect to the underlying


### PR DESCRIPTION
Tracking scope by making everything indexed over the number of free variables is nice, but I finally ran out of patience trying to figure out how to express some of the more advanced manipulations on contexts without using rewrites (see below).

So this PR gets rid of these indices and replaces them with separate well-formedness judgements. This is significantly more heavyweight, since one first writes the ML-like program and then separately proves that it is well behaved in terms of binding. But I think it is the right approach for now. 
# 

The straw that broke the camel's back for me was trying to figure out how to express the elimination rule for products:

```
H1, z : x:A * B, H2 >> C
    H1, z : x:A * B, a : A, b : [a/x]B, [(a,b)/z]H2 >> [(a,b)/z]C
```

This rule requires taking a telescope, inserting some elements in the middle, and performing a substitution on the rest of the telescope. In my opinion, this is just too delicate of an operation to be conveniently expressed with dependent de Bruijn indices.
